### PR TITLE
Footsoldiers updates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,32 +12,21 @@ jobs:
         os: [ubuntu-18.04]
 
     steps:
-      - uses: actions/checkout@v1
-      - name: Install Roswell
-        env:
-          LISP: ${{ matrix.lisp }}
-          ROSWELL_INSTALL_DIR: /usr
+      - name: Checkout code
+        uses: actions/checkout@v1
+
+      - name: Build docker container
         run: |
-          wget https://raw.githubusercontent.com/roswell/roswell/master/scripts/install-for-ci.sh
-          chmod +x ./install-for-ci.sh
-          ./install-for-ci.sh
-      - name: Install Rove
-        run: ros install rove
-      - name: Install qlot
-        run: ros install qlot
-      - name: Install dependencies
-        run: |
-          PATH="~/.roswell/bin:$PATH"
-          qlot install
+          docker build . --tag footsoldiers-runner
+
       - name: Run game runner tests      
         run: |
-          PATH="~/.roswell/bin:$PATH"
-          rove game-runner/game-runner.asd
+          docker run --entrypoint /home/footsoldiers/.roswell/bin/rove footsoldiers-runner game-runner/game-runner.asd
+
       - name: Run runtime tests
         run: |
-          PATH="~/.roswell/bin:$PATH"
-          rove runtime/runtime.asd
+          docker run --entrypoint /home/footsoldiers/.roswell/bin/rove footsoldiers-runner runtime/runtime.asd
+
       - name: Run footsoldiers tests
         run: |
-          PATH="~/.roswell/bin:$PATH"
-          rove footsoldiers/footsoldiers.asd
+          docker run --entrypoint /home/footsoldiers/.roswell/bin/rove footsoldiers-runner footsoldiers/footsoldiers.asd

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ RUN apt-get update && \
 USER footsoldiers
 RUN ros install sbcl-bin/2.2.0 && \
  ros install qlot && \
+ ros install rove && \
+ mkdir -p /home/footsoldiers/.config/common-lisp && \
+ echo "(:source-registry (:tree (:home \"bot-match\")) :inherit-configuration)" > /home/footsoldiers/.config/common-lisp/source-registry.conf && \
  /home/footsoldiers/.roswell/bin/qlot install && \
  ros run --load footsoldiers/build.lisp && \
  chmod +x /home/footsoldiers/bot-match/footsoldiers

--- a/footsoldiers/game-config.json
+++ b/footsoldiers/game-config.json
@@ -9,9 +9,9 @@
     },
     "bot-memory-limit-kib": 1048576,
     "health": {
-        "scout": 6,
+        "scout": 10,
         "assassin": 6,
-        "tank": 6
+        "tank": 12
     },
     "speed": {
         "scout": 3,
@@ -19,7 +19,7 @@
         "tank": 2
     },
     "damage": {
-        "scout": 2,
+        "scout": 3,
         "assassin": 5,
         "tank": 2
     },

--- a/footsoldiers/game-config.json
+++ b/footsoldiers/game-config.json
@@ -2,6 +2,7 @@
     "initial-money": 10,
     "money-per-turn": 3,
     "max-distance-from-base": 5,
+    "total-turns": 100,
     "allowed-commands": {
         "lisp-ros": "ros dynamic-space-size=800 +Q -- <bot-file>",
         "lisp-ros-herodotus": "ros dynamic-space-size=800 -Q -s herodotus -- <bot-file>"

--- a/footsoldiers/src/footsoldiers.lisp
+++ b/footsoldiers/src/footsoldiers.lisp
@@ -137,6 +137,7 @@
     ((initial-money)
      (money-per-turn)
      (max-distance-from-base)
+     (total-turns)
      (bot-memory-limit-kib)
      (allowed-commands)
      (health health-config)
@@ -169,6 +170,7 @@
   (make-instance 'game-config 
    :initial-money 10
    :money-per-turn 3 
+   :total-turns 100
    :allowed-commands (alist-hash-table 
                       (list (cons "lisp-ros" "ros +Q -- <bot-file>"))
                       :test 'equal)
@@ -616,7 +618,7 @@
                      (let* ((bots (alist-hash-table (pairlis '("player1" "player2") bs)
                                                     :test 'equal))
                             (game (make-game :map (map-details-map game-map)
-                                             :turns-remaining 100
+                                             :turns-remaining (total-turns game-config)
                                              :player1 (make-player 
                                                        :team "player1" 
                                                        :money (initial-money game-config)

--- a/footsoldiers/tests/footsoldiers.lisp
+++ b/footsoldiers/tests/footsoldiers.lisp
@@ -871,8 +871,8 @@
   (testing "runs bots and plays game until it is finished"
     (let ((result (start-game 
                    (cons "bot1/" "bot2/")
-                   (make-logging-config :turns nil
-                                        :moves *standard-output*
+                   (make-logging-config :turns *standard-output*
+                                        :moves nil
                                         :states nil
                                         :visualisation nil)
                    :current-directory (directory-namestring #.*compile-file-truename*)

--- a/footsoldiers/tests/footsoldiers.lisp
+++ b/footsoldiers/tests/footsoldiers.lisp
@@ -880,6 +880,7 @@
                                  'game-config
                                  :initial-money 10
                                  :money-per-turn 3
+                                 :total-turns 100
                                  :allowed-commands 
                                  (alist-hash-table
                                   (list (cons "lisp-ros-herodotus"

--- a/game-runner/src/n-player-game.lisp
+++ b/game-runner/src/n-player-game.lisp
@@ -59,6 +59,9 @@
               (game-state (game-turn-result-game turn-result)))
       (format (logging-config-visualisation logging-config) "~a~%"
               (game-visualisation (game-turn-result-game turn-result)))
+      (force-output (logging-config-moves logging-config))
+      (force-output (logging-config-turns logging-config))
+      (force-output (logging-config-states logging-config))
       (cons new-bots (game-turn-result-game turn-result)))))
 
 (defparameter *termination-timeout* 0.5)

--- a/runtime/tests/runtime.lisp
+++ b/runtime/tests/runtime.lisp
@@ -72,7 +72,8 @@
                                                      *test-base-path* *standard-output*
                                                      :memory-limit 10)))
         (sleep 0.01)
-        (ok (equalp (fmap #'bot-status initial-bot) (right :exited)))))))
+        (ok (or (equalp (fmap #'bot-status initial-bot) (right :exited))
+                (equalp (fmap #'bot-status initial-bot) (right :signaled))))))))
 
 (deftest readiness-check
   (testing "should kill a bot if it fails to respond with ready within the time limit"


### PR DESCRIPTION
Allow toggling printing logs to stdout as well as to file.

Fix bug in search for reachable positions where manhattan distance from start was used as limit instead of travel distance.

Adjust defaults settings in config file for bot attributes.

Fix testing error when running runtime tests in docker container.

Run tests in docker container.