### PR TITLE
Support running out of tree bots

### DIFF
--- a/footsoldiers/game-config.json
+++ b/footsoldiers/game-config.json
@@ -5,7 +5,8 @@
     "total-turns": 100,
     "allowed-commands": {
         "lisp-ros": "ros dynamic-space-size=800 +Q -- <bot-file>",
-        "lisp-ros-herodotus": "ros dynamic-space-size=800 -Q -s herodotus -- <bot-file>"
+        "lisp-ros-herodotus": "ros dynamic-space-size=800 -Q -s herodotus -- <bot-file>",
+        "execute-binary": "<bot-file>"
     },
     "bot-memory-limit-kib": 1048576,
     "health": {

--- a/run-a-match.sh
+++ b/run-a-match.sh
@@ -7,4 +7,13 @@ if [[ "$1" == "" || "$2" == "" ]]; then
     exit 1
 fi
 
-docker run bot-runner --config-file-path ./footsoldiers/game-config.json --map-file-path ./footsoldiers/game-map --bot-dir-1 "$1" --bot-dir-2 "$2"
+# Source: https://unix.stackexchange.com/questions/24293/converting-relative-path-to-absolute-path-without-symbolic-link
+if [ -d "$1" ]; then DIRECTORY_OF_BOT_1=$1/.; fi
+DIRECTORY_OF_BOT_1=$(cd "$(dirname -- "$DIRECTORY_OF_BOT_1")"; printf %s. "$PWD")
+DIRECTORY_OF_BOT_1=${DIRECTORY_OF_BOT_1%?}
+
+if [ -d "$2" ]; then DIRECTORY_OF_BOT_2=$2/.; fi
+DIRECTORY_OF_BOT_2=$(cd "$(dirname -- "$DIRECTORY_OF_BOT_2")"; printf %s. "$PWD")
+DIRECTORY_OF_BOT_2=${DIRECTORY_OF_BOT_2%?}
+
+docker run -v "$DIRECTORY_OF_BOT_1":"$DIRECTORY_OF_BOT_1" -v "$DIRECTORY_OF_BOT_2":"$DIRECTORY_OF_BOT_2" bot-runner --config-file-path ./footsoldiers/game-config.json --map-file-path ./footsoldiers/game-map --bot-dir-1 "$DIRECTORY_OF_BOT_1" --bot-dir-2 "$DIRECTORY_OF_BOT_2"


### PR DESCRIPTION
 - Add a command to the config file that runs binary files as bots.
 - Mount arbitrary host directories that contain bots in the script `run-a-match.sh`.