### PR TITLE
Add java to runner docker container. Increase bot memory limit.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,50 @@
 FROM ubuntu:21.04
 
+RUN apt-get update
+RUN apt-get install -y wget
+RUN apt-get install tar
+RUN wget https://github.com/roswell/roswell/releases/download/v20.01.14.104/roswell_20.01.14.104-1_amd64.deb
+RUN apt-get install -y libcurl3-gnutls
+RUN apt-get install -y git
+RUN apt-get install -y bzip2
+RUN apt-get install -y make
+RUN dpkg -i roswell_20.01.14.104-1_amd64.deb
+
+RUN apt-get install -y zip
+RUN apt-get install -y unzip
+RUN apt-get install -y curl
+RUN apt-get install -y gnupg
+
+# Add key for Azul java build
+RUN apt-key adv \
+  --keyserver hkp://keyserver.ubuntu.com:80 \
+  --recv-keys 0xB1998361219BD9C9
+
+# Add Azul apt repository
+RUN curl -O https://cdn.azul.com/zulu/bin/zulu-repo_1.0.0-3_all.deb
+RUN apt-get install ./zulu-repo_1.0.0-3_all.deb
+RUN apt-get update
+
+# Install openjre 17
+RUN apt-get install -y zulu17-jre
+
 RUN useradd -ms /bin/bash footsoldiers
+
+USER footsoldiers
+RUN ros install sbcl-bin/2.2.0
+RUN ros install qlot
+RUN ros install rove
+RUN mkdir -p /home/footsoldiers/.config/common-lisp
+RUN echo "(:source-registry (:tree (:home \"bot-match\")) :inherit-configuration)" > /home/footsoldiers/.config/common-lisp/source-registry.conf
+
+USER root
 ADD . /home/footsoldiers/bot-match
 WORKDIR /home/footsoldiers/bot-match
-
 RUN chown -R footsoldiers .
-
-RUN apt-get update && \
- apt-get install -y wget && \
- apt-get install tar && \
- wget https://github.com/roswell/roswell/releases/download/v20.01.14.104/roswell_20.01.14.104-1_amd64.deb && \
- apt-get install -y libcurl3-gnutls && \
- apt-get install -y git && \
- apt-get install -y bzip2 && \
- apt-get install -y make && \
- dpkg -i roswell_20.01.14.104-1_amd64.deb 
- 
 USER footsoldiers
-RUN ros install sbcl-bin/2.2.0 && \
- ros install qlot && \
- ros install rove && \
- mkdir -p /home/footsoldiers/.config/common-lisp && \
- echo "(:source-registry (:tree (:home \"bot-match\")) :inherit-configuration)" > /home/footsoldiers/.config/common-lisp/source-registry.conf && \
- /home/footsoldiers/.roswell/bin/qlot install && \
- ros run --load footsoldiers/build.lisp && \
- chmod +x /home/footsoldiers/bot-match/footsoldiers
+
+RUN /home/footsoldiers/.roswell/bin/qlot install
+RUN ros run --load footsoldiers/build.lisp
+RUN chmod +x /home/footsoldiers/bot-match/footsoldiers
 
 ENTRYPOINT ["/home/footsoldiers/bot-match/footsoldiers-runner"]

--- a/example-bots/java/app/src/main/java/bot/Bot.java
+++ b/example-bots/java/app/src/main/java/bot/Bot.java
@@ -13,12 +13,13 @@ public class Bot {
 
     public static void main(String[] args) {
         try {
+            ObjectMapper mapper = new ObjectMapper()
+                .configure(JsonParser.Feature.AUTO_CLOSE_SOURCE, false)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
             
             System.out.println("READY");
             while (true) {
-                ObjectMapper mapper = new ObjectMapper()
-                    .configure(JsonParser.Feature.AUTO_CLOSE_SOURCE, false)
-                    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             
                 Input input = mapper.readValue(System.in, Input.class);
                 while (System.in.available() > 0) {

--- a/footsoldiers/game-config.json
+++ b/footsoldiers/game-config.json
@@ -7,9 +7,9 @@
         "lisp-ros": "ros dynamic-space-size=800 +Q -- <bot-file>",
         "lisp-ros-herodotus": "ros dynamic-space-size=800 -Q -s herodotus -- <bot-file>",
         "execute-binary": "<bot-file>",
-        "java-jar": "java -jar <bot-file> -Xmx800m"
+        "java-jar": "java -jar <bot-file>"
     },
-    "bot-memory-limit-kib": 1048576,
+    "bot-memory-limit-kib": 2621440,
     "health": {
         "scout": 10,
         "assassin": 6,


### PR DESCRIPTION
Installs java in the game runner container to allow running games with java bots.

Increases the memory limit for bots to prevent compressed class space allocation failure for jvm.