### PR TITLE
Print turns and errors and mount config from outside container

### DIFF
--- a/run-a-match.sh
+++ b/run-a-match.sh
@@ -16,4 +16,13 @@ if [ -d "$2" ]; then DIRECTORY_OF_BOT_2=$2/.; fi
 DIRECTORY_OF_BOT_2=$(cd "$(dirname -- "$DIRECTORY_OF_BOT_2")"; printf %s. "$PWD")
 DIRECTORY_OF_BOT_2=${DIRECTORY_OF_BOT_2%?}
 
-docker run -v "$DIRECTORY_OF_BOT_1":"$DIRECTORY_OF_BOT_1" -v "$DIRECTORY_OF_BOT_2":"$DIRECTORY_OF_BOT_2" bot-runner --config-file-path ./footsoldiers/game-config.json --map-file-path ./footsoldiers/game-map --bot-dir-1 "$DIRECTORY_OF_BOT_1" --bot-dir-2 "$DIRECTORY_OF_BOT_2"
+docker run -v "$DIRECTORY_OF_BOT_1":"$DIRECTORY_OF_BOT_1" \
+       -v "$DIRECTORY_OF_BOT_2":"$DIRECTORY_OF_BOT_2" \
+       -v "$(PWD)/footsoldiers":"/config" \
+       bot-runner \
+       --print-bot-errors \
+       --print-turns \
+       --config-file-path /config/game-config.json \
+       --map-file-path ./footsoldiers/game-map \
+       --bot-dir-1 "$DIRECTORY_OF_BOT_1" \
+       --bot-dir-2 "$DIRECTORY_OF_BOT_2"


### PR DESCRIPTION
Adds two flags to the `run-a-match.sh` script:
 - `--print-bot-errors`, and
 - `--print-turns`.

Also, mounts the config directory in-tree from the bot repo so that you can easily change the config without rebuilding the container.