### PR TITLE
Ignore a few files and folders when building the bot runner image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile
+.git/
+.qlot/
+.github/
+example-bots/


### PR DESCRIPTION
Ignore some files and folders that definitely shouldn't be a part of the docker build context for the runner.