### PR TITLE
Adjust error handling

### DIFF
--- a/footsoldiers/src/footsoldiers.lisp
+++ b/footsoldiers/src/footsoldiers.lisp
@@ -683,7 +683,7 @@
   (let ((config (make-docker-config image :open-stdin t
                                     :memory memory-limit 
                                     :memory-swap (* memory-limit 2)
-                                    :read-only-root-fs t)))
+                                    :readonly-rootfs t)))
     (create-container name :docker-config config)))
 
 

--- a/footsoldiers/tests/footsoldiers.lisp
+++ b/footsoldiers/tests/footsoldiers.lisp
@@ -1142,7 +1142,8 @@
                   :volumes (list "/bots")
                   :memory (* 1024 (bot-memory-limit-kib *default-game-config*))
                   :memory-swap (* 2 1024 (bot-memory-limit-kib *default-game-config*))
-                  :read-only-root-fs t
+                  ;; need to disable read-only fs so that ql cache can be updated in test
+                  :readonly-rootfs nil
                   :binds (list (format nil "~a:/bots" 
                                        (merge-pathnames bot-directory *test-base-path*))))))
     (create-container name :docker-config config)))

--- a/game-runner/tests/guessing-game.lisp
+++ b/game-runner/tests/guessing-game.lisp
@@ -73,7 +73,7 @@
                   :entrypoint (list "")
                   :open-stdin t
                   :volumes (list "/bots")
-                  :read-only-root-fs t
+                  :readonly-rootfs t
                   :binds (list (format nil "~a:/bots" 
                                        (merge-pathnames bot-directory *base-path*))))))
     (create-container bot-file :docker-config config)))

--- a/runtime/tests/definition.json
+++ b/runtime/tests/definition.json
@@ -1,5 +1,3 @@
 {
-    "name": "turn-bot.lisp",
-    "filename": "turn-bot.lisp",
-    "command": "lisp-ros"
+    "name": "turn-bot.lisp"
 }

--- a/runtime/tests/filesystem-bot-definition.json
+++ b/runtime/tests/filesystem-bot-definition.json
@@ -1,5 +1,3 @@
 {
-    "name": "filesystem-bot.lisp",
-    "filename": "filesystem-bot.lisp",
-    "command": "lisp-ros"
+    "name": "filesystem-bot.lisp"
 }

--- a/runtime/tests/not-ready-bot-definition.json
+++ b/runtime/tests/not-ready-bot-definition.json
@@ -1,5 +1,3 @@
 {
-    "name": "not-ready-bot.lisp",
-    "filename": "not-ready-bot.lisp",
-    "command": "lisp-ros"
+    "name": "not-ready-bot.lisp"
 }

--- a/runtime/tests/runtime.lisp
+++ b/runtime/tests/runtime.lisp
@@ -52,7 +52,7 @@
 
 (defmacro with-test-bot (var identifier error-stream &rest body)
   (with-gensyms (bot-process)
-    `(let* ((,bot-process (run-bot ,identifier))
+    `(let* ((,bot-process (right-value (run-bot ,identifier)))
             (,var (make-instance 'concrete-bot
                                  :bot-process ,bot-process
                                  :bot-id (random 100)

--- a/runtime/tests/turn-bot.lisp
+++ b/runtime/tests/turn-bot.lisp
@@ -13,4 +13,7 @@
     (finish-output)
     (sleep 20)))
 
-(run)
+(defun main (&rest argv)
+  "Start the bot."
+  (declare (ignorable argv))
+  (run))


### PR DESCRIPTION
Returns either from bot-status, has-exited and initialise-bot.

Fixes mistake in json for configuring readonly root file system in container. 

Adds test that checks that readonly file system causes a bot to exit when it tries to write a file.